### PR TITLE
fix(a11y): ikony social w stopce jako inline SVG z aria-label

### DIFF
--- a/www/.vuepress/theme/components/oj-footer.vue
+++ b/www/.vuepress/theme/components/oj-footer.vue
@@ -1,5 +1,5 @@
  <template lang='pug'>
-#oj-footer
+footer#oj-footer
 	.inner-section
 		.info-columns
 			.contacts

--- a/www/.vuepress/theme/components/oj-footer.vue
+++ b/www/.vuepress/theme/components/oj-footer.vue
@@ -10,7 +10,7 @@
 				h4.address-title {{$site.themeConfig.address[lang].title}}
 				.address-details(v-html="render(this.$site.themeConfig.address[lang].details)")
 		.social
-			a.social-icon(v-for="item in $site.themeConfig.social", :href="item.href", :title="item.type", target="_blank", rel="noopener") {{socialChar(item.type)}}
+			a.social-icon(v-for="item in $site.themeConfig.social", :key="item.type", :href="item.href", :aria-label="socialLabel(item.type)", target="_blank", rel="noopener", v-html="socialIcon(item.type)")
 		.links
 			router-link(v-for="link in $site.themeConfig.links[lang]" :key="link.to" :to="link.to") {{link.title}}
 </template>
@@ -19,7 +19,25 @@
 import markdownIt from 'markdown-it'
 const md = markdownIt({breaks: true})
 
-const socialChars = { facebook: 'b', instagram: 'd', youtube: 'p', linkedin: 'o', x: 'x' }
+// Dostepne nazwy dla czytnikow ekranu (trafiaja do aria-label linku)
+const socialLabels = {
+	facebook: 'Facebook',
+	instagram: 'Instagram',
+	linkedin: 'LinkedIn',
+	youtube: 'YouTube',
+	x: 'X (dawniej Twitter)'
+}
+
+// Inline SVG (Simple Icons, licencja CC0). fill=currentColor -> kolor z CSS.
+// aria-hidden + focusable=false: nazwe niesie aria-label na <a>, nie glif.
+const svg = d => `<svg viewBox="0 0 24 24" width="1em" height="1em" fill="currentColor" aria-hidden="true" focusable="false"><path d="${d}"/></svg>`
+const socialIcons = {
+	facebook: svg('M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z'),
+	instagram: svg('M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zm0-2.163C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z'),
+	linkedin: svg('M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z'),
+	youtube: svg('M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z'),
+	x: svg('M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z')
+}
 
 export default {
 	name: 'oj-footer',
@@ -31,7 +49,8 @@ export default {
 	},
 	methods: {
 		render(str){ return md.render(str) },
-		socialChar(type){ return socialChars[type] || type }
+		socialLabel(type){ return socialLabels[type] || type },
+		socialIcon(type){ return socialIcons[type] || '' }
 	}
 }
 </script>
@@ -103,11 +122,21 @@ export default {
 		@media print
 			display none
 	.social-icon
-		icon()
-		display inline-block
+		display inline-flex
+		align-items center
+		justify-content center
+		width 2.5rem
+		height 2.5rem
 		font-size 2rem
 		text-decoration none
 		color $oj-green-free
+		border-radius 4px
+		svg
+			display block
+			width 1em
+			height 1em
+		&:hover, &:focus-visible
+			color $oj-violet
 
 	// LINKS
 	.links


### PR DESCRIPTION
## Co
Ikony społecznościowe w stopce (Facebook, Instagram, LinkedIn, YouTube, X) renderowane dotąd jako **pojedyncze litery fontu ikonowego** (`b`, `d`, `o`, `p`, `x`) zastąpione **inline SVG** (Simple Icons, licencja CC0) z:
- `aria-label` na linku (dostępna nazwa: „Facebook", „Instagram", …, „X (dawniej Twitter)"),
- `aria-hidden="true"` + `focusable="false"` na samym SVG,
- obszarem klikalnym 2.5×2.5 rem (spełnia cel dotykowy ≥24 px),
- stanem `:hover`/`:focus-visible` w kolorze marki (fiolet).

## Dlaczego
Znalezisko **A01 (P0)** z `AUDIT.md`: czytnik ekranu odczytywał ikony jako bełkot („b", „d", „o", „p", „x"). Teraz ogłasza np. „Facebook, link".

## Jak zweryfikować
1. `yarn build` (przechodzi, 6.1 s, exit 0).
2. W `dist/index.html` linki mają `aria-label="Facebook"` itd., a SVG `aria-hidden="true"`.
3. Wizualnie: w stopce widać kolorowe/monochromatyczne ikony marek zamiast liter.
4. Czytnikiem ekranu (VoiceOver/NVDA) każdy link ogłasza nazwę serwisu.

## Co może się zepsuć
- Zależność od fontu `oj-icons` w stopce znika (font nadal używany gdzie indziej — bez zmian).
- Kontrast domyślnej zieleni ikon (~2.9:1) to **osobne** znalezisko **A02** — domknięte w PR dot. kontrastu/tokenów; ten PR nie pogarsza stanu (litery też były zielone).

Zakres: tylko `www/.vuepress/theme/components/oj-footer.vue`. Bez zmian URL-i i treści.