### PR TITLE
fix(a11y): kontrast, menu klawiaturą, skip link, landmarki, alt, focus

### DIFF
--- a/www/.vuepress/theme/components/oj-intro.vue
+++ b/www/.vuepress/theme/components/oj-intro.vue
@@ -3,9 +3,10 @@
 		article.content
 			section.photos
 				.photo(v-for="(image, i) in $page.frontmatter.images", :class="'p'+i", :style="styles['shift'+i]")
-					img(:src="image")
+					img(:src="image", alt="")
 			section.text
-				h1.title {{$page.frontmatter.intro}}
+				h1.sr-only Wolny Jazdów
+				p.hero-lead {{$page.frontmatter.intro}}
 				oj-expander
 					Content.extended
 </template>
@@ -40,7 +41,11 @@ export default {
 	},
 
 	mounted() {
-		window.addEventListener('scroll', this.scrollEvents)
+		// Paralaksa tylko gdy uzytkownik nie prosi o ograniczenie ruchu (A08)
+		const reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches
+		if (!reduce) {
+			window.addEventListener('scroll', this.scrollEvents)
+		}
 	},
 
 	destroyed(){
@@ -86,6 +91,13 @@ export default {
 	+below(700px)
 		max-width 40rem
 		margin 6rem auto 0
+	.hero-lead
+		font-family $extra_font_family
+		font-size 1.8rem
+		font-weight 700
+		line-height 1.4em
+		letter-spacing .02em
+		margin-bottom 1em
 .extended
 	display block
 	hyphens auto

--- a/www/.vuepress/theme/components/oj-menu.vue
+++ b/www/.vuepress/theme/components/oj-menu.vue
@@ -1,10 +1,11 @@
 <template lang="pug">
-	.oj-menu
-		a.icon(@click="toggleMenu()", :class="{on: mobileMenu}") menu
-		nav
+	header.oj-menu
+		a.skip-link(href="#main-content") {{skipLabel}}
+		button.icon(type="button", ref="toggle", @click="toggleMenu()", :class="{on: mobileMenu}", :aria-expanded="mobileMenu ? 'true' : 'false'", aria-controls="main-nav", :aria-label="mobileMenu ? closeLabel : menuLabel") menu
+		nav(:aria-label="navLabel")
 			router-link.home(:to="$localePath", :title="$siteTitle")
 				img.logo(:src="logo", :alt="$siteTitle")
-			.items(:class="{on: mobileMenu}")
+			.items#main-nav(:class="{on: mobileMenu}")
 				router-link(v-for="item in $site.themeConfig.mainMenu[lang]", :key="item.href", :to="item.href") {{item.title}}
 				router-link.lang-switch(:to="langSwitch.to") {{langSwitch.name}}
 </template>
@@ -23,6 +24,11 @@ export default {
 	computed: {
 		lang(){ return this.$lang.substring(0, 2) },
 		logo(){ return require('../assets/ui/logo-wj.png') },
+		isEn(){ return this.lang === 'en' },
+		skipLabel(){ return this.isEn ? 'Skip to content' : 'Przejdź do treści' },
+		menuLabel(){ return this.isEn ? 'Open menu' : 'Otwórz menu' },
+		closeLabel(){ return this.isEn ? 'Close menu' : 'Zamknij menu' },
+		navLabel(){ return this.isEn ? 'Main' : 'Główne' },
 		langSwitch(){
 			return {
 				to: this.$lang === 'pl-PL' ? '/en/' : '/',
@@ -37,14 +43,22 @@ export default {
 		},
 		closeMenu(){
 			this.mobileMenu = false
+		},
+		onKeydown(e){
+			if (e.key === 'Escape' && this.mobileMenu) {
+				this.closeMenu()
+				this.$refs.toggle && this.$refs.toggle.focus()
+			}
 		}
 	},
 	watch: {
 		mobileMenu(next){
 			if (next) {
-				return document.body.classList.add('menu-on')
+				document.body.classList.add('menu-on')
+				document.addEventListener('keydown', this.onKeydown)
 			} else {
-				return document.body.classList.remove('menu-on')
+				document.body.classList.remove('menu-on')
+				document.removeEventListener('keydown', this.onKeydown)
 			}
 		},
 		$route(){
@@ -53,6 +67,7 @@ export default {
 	},
 	beforeDestroy(){
 		document.body.classList.remove('menu-on')
+		document.removeEventListener('keydown', this.onKeydown)
 	}
 }
 </script>
@@ -92,12 +107,15 @@ nav
 	a
 		text-decoration: none
 
-a.icon
+button.icon
 	display none
 	position fixed
 	top .5rem
 	right 1rem
 	z-index 9999
+	background transparent
+	border none
+	font-family $Lemur
 	color $oj-green-free
 	text-transform uppercase
 	font-size 1rem

--- a/www/.vuepress/theme/layouts/Events.vue
+++ b/www/.vuepress/theme/layouts/Events.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
 .default
 	oj-menu
-	main
+	main#main-content(tabindex="-1")
 		#events-view
 			.intro
 				h1.title {{$page.frontmatter.title}}

--- a/www/.vuepress/theme/layouts/History.vue
+++ b/www/.vuepress/theme/layouts/History.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .default
 	oj-menu
-	main
+	main#main-content(tabindex="-1")
 		#history-view(v-if="$page.frontmatter")
 			.intro
 				h1.title {{$page.frontmatter.title}}

--- a/www/.vuepress/theme/layouts/Home.vue
+++ b/www/.vuepress/theme/layouts/Home.vue
@@ -7,7 +7,7 @@
 			.content
 				.row.a
 					a.banner-plakat(href="https://jazdow.pl/plakaty/2026_08.png" target="_blank" rel="noopener")
-						img(src="/plakaty/aktualny_plakat.png" alt="Plakat z aktualnymi wydarzeniami na Osiedlu Jazdów – otwórz pełną wersję")
+						img(src="/plakaty/aktualny_plakat.png" width="1890" height="870" alt="Plakat z aktualnymi wydarzeniami na Osiedlu Jazdów – otwórz pełną wersję")
 				.row.b
 					oj-card(v-for="(card, i) in $page.frontmatter.cards"
 					:key="i"

--- a/www/.vuepress/theme/layouts/Home.vue
+++ b/www/.vuepress/theme/layouts/Home.vue
@@ -1,19 +1,20 @@
 <template lang="pug">
-main
+.home
 	oj-menu
-	#home-page
-		oj-intro
-		.content
-			.row.a
-				a.banner-plakat(href="https://jazdow.pl/plakaty/2026_08.png" target="_blank" rel="noopener")
-					img(src="/plakaty/aktualny_plakat.png" alt="Aktualny plakat zbiorczy")
-			.row.b
-				oj-card(v-for="(card, i) in $page.frontmatter.cards"
-				:key="i"
-				:title="card.title"
-				:caption="card.caption"
-				:cover="card.cover"
-				:link="card.link")
+	main#main-content(tabindex="-1")
+		#home-page
+			oj-intro
+			.content
+				.row.a
+					a.banner-plakat(href="https://jazdow.pl/plakaty/2026_08.png" target="_blank" rel="noopener")
+						img(src="/plakaty/aktualny_plakat.png" alt="Plakat z aktualnymi wydarzeniami na Osiedlu Jazdów – otwórz pełną wersję")
+				.row.b
+					oj-card(v-for="(card, i) in $page.frontmatter.cards"
+					:key="i"
+					:title="card.title"
+					:caption="card.caption"
+					:cover="card.cover"
+					:link="card.link")
 	oj-footer
 </template>
 

--- a/www/.vuepress/theme/layouts/Houses.vue
+++ b/www/.vuepress/theme/layouts/Houses.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .default
 	oj-menu
-	main
+	main#main-content(tabindex="-1")
 		#view-house
 			header#header
 				h1#org-name {{$page.frontmatter.title}}
@@ -10,7 +10,7 @@
 				section#main
 					#image-gallery(v-if="$page.frontmatter.images")
 						oj-slider(captions, controls, counter, loop)
-							img(v-for="image in $page.frontmatter.images", :src="image.src", :caption="image.caption")
+							img(v-for="image in $page.frontmatter.images", :src="image.src", :caption="image.caption", :alt="image.caption")
 					#content
 						Content.house-body
 

--- a/www/.vuepress/theme/layouts/Layout.vue
+++ b/www/.vuepress/theme/layouts/Layout.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .default
 	oj-menu
-	main
+	main#main-content(tabindex="-1")
 		.page-view
 			.intro
 				h1.title {{$page.frontmatter.title}}

--- a/www/.vuepress/theme/layouts/Map.vue
+++ b/www/.vuepress/theme/layouts/Map.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
 .default
 	oj-menu
-	main
+	main#main-content(tabindex="-1")
 		#view-map
 			.intro
 				h1.title {{$page.frontmatter.title}}

--- a/www/.vuepress/theme/styles/imports/variables.styl
+++ b/www/.vuepress/theme/styles/imports/variables.styl
@@ -10,7 +10,9 @@ $oj-violet 		= #5200cc
 $oj-ck          = #060E9F
 $oj-red         = #e43857
 $oj-green		= #1afcaf
-$oj-green-free	= #6ba568
+// #477f42: przyciemniona wersja marki (#6ba568) — kontrast >=4.5:1 na bieli (WCAG AA).
+// Uzywana dla tekstu/linkow/obramowan/ikon; znalezisko A02 z AUDIT.md.
+$oj-green-free	= #477f42
 $oj-palegreen	= #b6efbb
 $oj-palegreen2	= #a4d7a9
 $oj-dark-green  = #66A16C

--- a/www/.vuepress/theme/styles/index.styl
+++ b/www/.vuepress/theme/styles/index.styl
@@ -21,3 +21,51 @@ body
 	// grid-guide(12, $gutter, $grid-width, $gutter)
 *
 	box-sizing border-box
+
+// ! DOSTEPNOSC (A07, A09 z AUDIT.md)
+
+// Widoczny pierscien focusu z klawiatury
+a:focus-visible,
+button:focus-visible,
+[tabindex]:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible
+	outline 3px solid $oj-violet
+	outline-offset 2px
+	border-radius 2px
+
+// Tekst tylko dla czytnikow ekranu
+.sr-only
+	position absolute
+	width 1px
+	height 1px
+	padding 0
+	margin -1px
+	overflow hidden
+	clip rect(0 0 0 0)
+	white-space nowrap
+	border 0
+
+// Link "przejdz do tresci" — widoczny dopiero po fokusie z klawiatury
+.skip-link
+	position absolute
+	left 1rem
+	top -3rem
+	z-index 10000
+	padding .5rem 1rem
+	background $oj-violet
+	color white
+	text-decoration none
+	border-radius 0 0 4px 4px
+	transition top .15s ease
+	&:focus
+		top 0
+
+// Redukcja ruchu (A08)
+@media (prefers-reduced-motion: reduce)
+	*
+		animation-duration .001ms !important
+		animation-iteration-count 1 !important
+		transition-duration .001ms !important
+		scroll-behavior auto !important


### PR DESCRIPTION
Domyka pozostałe znaleziska dostępności z punktu 1 Sesji 2 (poza ikonami social — osobny PR #186).

## Co
- **A02 — kontrast (P0):** `$oj-green-free` `#6ba568` → **`#477f42`** (jedyna zmienna, kaskaduje na tekst/linki/obramowania/ikony). Kontrast na bieli **2.9:1 → 4.79:1** (AA dla tekstu). Wartość dobrana jako najjaśniejszy odcień marki spełniający ≥4.5:1 (minimalny drift wizualny).
- **A03 — menu klawiaturą (P0):** hamburger `<a>` → `<button type=button>` z `aria-expanded`, `aria-controls="main-nav"`, `aria-label` (Otwórz/Zamknij menu); **Esc** zamyka i przywraca focus na przycisk.
- **A07 — skip link + landmarki:** „Przejdź do treści"/„Skip to content" jako pierwszy element; `<header>`, `<nav aria-label>`, `<main id="main-content" tabindex="-1">` we wszystkich 6 layoutach; na home `oj-menu`/`oj-footer` wyjęte poza `<main>`.
- **A09 — focus ring:** globalny `:focus-visible` (fioletowy, offset 2px).
- **A04/A05 — alt:** `alt=""` dla dekoracyjnych zdjęć paralaksy intro; opisowy `alt` plakatu na home; `alt` galerii domków z istniejącego podpisu.
- **A06 — nagłówek:** zwięzły `<h1>Wolny Jazdów</h1>` (sr-only), zdanie-lead zdemotowane do `<p class="hero-lead">` z zachowaniem wyglądu.
- **A08 — ruch:** `@media (prefers-reduced-motion: reduce)` globalnie + wyłączenie paralaksy JS w oj-intro.

## Dlaczego
Znaleziska A02–A09 (P0/P1/P2) z `AUDIT.md`.

## Jak zweryfikować
1. `yarn build` — przechodzi (6.4 s, exit 0).
2. Tab od góry strony: pierwszy focus = „Przejdź do treści"; Enter przenosi do `<main>`.
3. Na wąskim ekranie: Tab dochodzi do przycisku menu, Enter/Spacja otwiera (`aria-expanded=true`), Esc zamyka i wraca focus.
4. `dist`: `<header class="oj-menu">`, `<nav aria-label>`, `<main id="main-content">`, `<h1 class="sr-only">Wolny Jazdów</h1>`, CSS zawiera `#477f42`.

## Różnica wizualna
- Zieleń tekstu/linków/ikon minimalnie ciemniejsza (sage → nieco głębszy sage). Grafiki rastrowe i zielone tło stopki bez zmian.
- Hero na home wygląda tak samo (zdanie w tym samym rozmiarze), zmienia się tylko semantyka (`h1`→`p` + ukryty `h1`).
- Pierścień focusu widoczny przy nawigacji klawiaturą.

## Co może się zepsuć
- Pozostały **2 literały `#6ba568`** w grafice mapy (`oj-map.vue`) — celowo, tokenizacja w punkcie 9.
- `hreflang` (A09) realizowany w PR `seo/open-graph` (wspólny mechanizm head).
- Landmark `<footer>` dołączony do PR #186 (który jest właścicielem `oj-footer.vue`).

Bez zmian URL-i i treści stron.