### PR TITLE
fix: martwy link /en/model/ → /en/co-management/

### DIFF
--- a/www/en/README.md
+++ b/www/en/README.md
@@ -25,7 +25,7 @@ cards:
     title: HISTORY —
   - caption: community-management of urban space
     cover: /images/cover-model.jpg
-    link: /en/model/
+    link: /en/co-management/
     title: MODEL —
   - caption: Jazdów Partnership
     cover: /images/cover-partnership.jpg

--- a/www/en/history.md
+++ b/www/en/history.md
@@ -18,7 +18,7 @@ history:
     date: January - December 2016
     text: 'We are creating a social space management model for the Jazdów area. The
         project is supported by The European Cultural Founda¬tion and other partners.
-        For more information visit [Model](/en/model/).'
+        For more information visit [Model](/en/co-management/).'
     title: Completion of the project „Community Management Model for Jazdów Settlement”
 -   
     date: May - December 2015


### PR DESCRIPTION
## Co
Dwa odwołania do nieistniejącego `/en/model/` (404) przekierowane na **istniejącą** stronę `/en/co-management/`:
- `www/en/history.md` — link w tekście historii („For more information visit Model").
- `www/en/README.md` — karta „MODEL —" na stronie głównej EN.

## Dlaczego
Punkt 2 Sesji 2 (uszkodzone linki). Pełny skan wszystkich wewnętrznych celów w treści wykazał **dokładnie jeden** martwy link — pozostałe 82 cele istnieją. Strona docelowa istnieje (to tłumaczenie `/wspolzarzadzanie`), więc link naprawiono, nie usunięto.

## Jak zweryfikować
1. `yarn build` — OK.
2. Ponowny skan wewnętrznych linków: brak 404.
3. Klik w kartę „MODEL" na `/en/` prowadzi do `/en/co-management/`.

## Co może się zepsuć
Nic — to naprawa istniejącego 404. **Nie** zmienia żadnego URL-a strony (należy do sesji 3/4).