### PR TITLE
chore(security): nagłówki bezpieczeństwa (netlify.toml + _headers)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,13 +12,7 @@
 		Referrer-Policy = "strict-origin-when-cross-origin"
 		Permissions-Policy = "geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=()"
 		Strict-Transport-Security = "max-age=31536000; includeSubDomains"
-		Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://identity.netlify.com; connect-src 'self' https://identity.netlify.com; frame-src 'self' https://identity.netlify.com; form-action 'self'; manifest-src 'self'"
-
-# Panel CMS potrzebuje luzniejszej polityki (unpkg + GitHub + Git Gateway).
-[[headers]]
-	for = "/admin/*"
-	[headers.values]
-		Content-Security-Policy = "default-src 'self' https: data: blob: 'unsafe-inline' 'unsafe-eval'"
+		Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; frame-src 'self'; form-action 'self'; manifest-src 'self'"
 
 # wersja Node-a jest tez w .nvmrc; tu trzymamy ja jawnie, zeby build byl przewidywalny
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,13 @@
 		Referrer-Policy = "strict-origin-when-cross-origin"
 		Permissions-Policy = "geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=()"
 		Strict-Transport-Security = "max-age=31536000; includeSubDomains"
-		Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; frame-src 'self'; form-action 'self'; manifest-src 'self'"
+		Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://identity.netlify.com; connect-src 'self' https://identity.netlify.com; frame-src 'self' https://identity.netlify.com; form-action 'self'; manifest-src 'self'"
+
+# Panel CMS potrzebuje luzniejszej polityki (unpkg + GitHub + Git Gateway).
+[[headers]]
+	for = "/admin/*"
+	[headers.values]
+		Content-Security-Policy = "default-src 'self' https: data: blob: 'unsafe-inline' 'unsafe-eval'"
 
 # wersja Node-a jest tez w .nvmrc; tu trzymamy ja jawnie, zeby build byl przewidywalny
 [build.environment]

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,24 @@
 	command = "yarn build"
 	publish = "www/.vuepress/dist"
 
+# Naglowki bezpieczenstwa (R09). Te same wartosci trzymamy w www/.vuepress/public/_headers
+# dla przenosnosci na Cloudflare Pages (sesja 7). Na Netlify aktywne sa ponizsze.
+[[headers]]
+	for = "/*"
+	[headers.values]
+		X-Frame-Options = "SAMEORIGIN"
+		X-Content-Type-Options = "nosniff"
+		Referrer-Policy = "strict-origin-when-cross-origin"
+		Permissions-Policy = "geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=()"
+		Strict-Transport-Security = "max-age=31536000; includeSubDomains"
+		Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://identity.netlify.com; connect-src 'self' https://identity.netlify.com; frame-src 'self' https://identity.netlify.com; form-action 'self'; manifest-src 'self'"
+
+# Panel CMS potrzebuje luzniejszej polityki (unpkg + GitHub + Git Gateway).
+[[headers]]
+	for = "/admin/*"
+	[headers.values]
+		Content-Security-Policy = "default-src 'self' https: data: blob: 'unsafe-inline' 'unsafe-eval'"
+
 # wersja Node-a jest tez w .nvmrc; tu trzymamy ja jawnie, zeby build byl przewidywalny
 [build.environment]
 	NODE_VERSION = "20"

--- a/www/.vuepress/public/_headers
+++ b/www/.vuepress/public/_headers
@@ -1,0 +1,16 @@
+# Naglowki bezpieczenstwa. Format dziala na Netlify ORAZ Cloudflare Pages
+# (dzieki temu sesja 7 nie bedzie ich przepisywac). Znalezisko R09 z AUDIT.md.
+# Te same wartosci sa w netlify.toml (aktywne na obecnym hostingu Netlify).
+
+/*
+  X-Frame-Options: SAMEORIGIN
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://identity.netlify.com; connect-src 'self' https://identity.netlify.com; frame-src 'self' https://identity.netlify.com; form-action 'self'; manifest-src 'self'
+
+# Panel CMS (Netlify CMS z unpkg + Git Gateway/GitHub) potrzebuje luzniejszej
+# polityki — nadpisujemy CSP dla /admin/*, reszta naglowkow z /* zostaje.
+/admin/*
+  Content-Security-Policy: default-src 'self' https: data: blob: 'unsafe-inline' 'unsafe-eval'

--- a/www/.vuepress/public/_headers
+++ b/www/.vuepress/public/_headers
@@ -8,4 +8,9 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; frame-src 'self'; form-action 'self'; manifest-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://identity.netlify.com; connect-src 'self' https://identity.netlify.com; frame-src 'self' https://identity.netlify.com; form-action 'self'; manifest-src 'self'
+
+# Panel CMS (Netlify CMS z unpkg + Git Gateway/GitHub) potrzebuje luzniejszej
+# polityki — nadpisujemy CSP dla /admin/*, reszta naglowkow z /* zostaje.
+/admin/*
+  Content-Security-Policy: default-src 'self' https: data: blob: 'unsafe-inline' 'unsafe-eval'

--- a/www/.vuepress/public/_headers
+++ b/www/.vuepress/public/_headers
@@ -8,9 +8,4 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), camera=(), microphone=(), payment=(), usb=(), interest-cohort=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' https://identity.netlify.com; connect-src 'self' https://identity.netlify.com; frame-src 'self' https://identity.netlify.com; form-action 'self'; manifest-src 'self'
-
-# Panel CMS (Netlify CMS z unpkg + Git Gateway/GitHub) potrzebuje luzniejszej
-# polityki — nadpisujemy CSP dla /admin/*, reszta naglowkow z /* zostaje.
-/admin/*
-  Content-Security-Policy: default-src 'self' https: data: blob: 'unsafe-inline' 'unsafe-eval'
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'self'; img-src 'self' data:; font-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self'; frame-src 'self'; form-action 'self'; manifest-src 'self'


### PR DESCRIPTION
Realizuje punkt 4 Sesji 2. Znalezisko **R09 (P1)** — dotąd produkcja wysyłała tylko `Strict-Transport-Security`.

## Co
Nagłówki bezpieczeństwa równolegle w `netlify.toml` (aktywne na Netlify) i `www/.vuepress/public/_headers` (przenośne na Cloudflare Pages).

**`/*`:** `X-Frame-Options: SAMEORIGIN`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy` (wyłączone geolokalizacja/kamera/mikrofon/płatności/usb/FLoC), `Strict-Transport-Security`, oraz `Content-Security-Policy` dopasowany do strony (brak inline JS; `identity.netlify.com` dozwolone dla widgetu logowania).

**`/admin/*`:** luźniejszy CSP dla panelu CMS (`default-src 'self' https: data: blob: 'unsafe-inline' 'unsafe-eval'`) — obsługuje Decap CMS (unpkg) + Netlify Identity + Git Gateway/GitHub.

## Uwaga historyczna
Był tu przejściowo commit usuwający obsługę `/admin`/Identity z CSP — **cofnięty** (revert), bo panel CMS zostaje (zaktualizowany do Decap w #198). Ten PR ponownie w pełni wspiera panel.

## ⚠️ Do przetestowania na deploy preview
CSP potrafi zablokować logowanie/CMS przy błędnej konfiguracji — **przed mergem sprawdzić `/admin/` (logowanie + zapis) na preview**. Powiązane: #198 (Decap CMS).

## Jak zweryfikować
1. `yarn build` — OK; `_headers` w `dist/`.
2. Po deployu: `curl -I https://jazdow.pl/` → komplet nagłówków. Redirecty (6 szt.) nienaruszone.