### PR TITLE
perf(images): lazy-loading obrazków z treści

### DIFF
--- a/www/.vuepress/config.js
+++ b/www/.vuepress/config.js
@@ -37,6 +37,17 @@ module.exports = {
 				linkify: true
 			})
 			md.use(require('markdown-it-footnote'))
+
+			// Obrazki z tresci sa niemal zawsze ponizej pierwszego ekranu — lazy
+			// oszczedza transfer, decoding=async nie blokuje watku (P04 z AUDIT.md).
+			const renderImage = md.renderer.rules.image
+			md.renderer.rules.image = (tokens, idx, options, env, self) => {
+				tokens[idx].attrSet('loading', 'lazy')
+				tokens[idx].attrSet('decoding', 'async')
+				return renderImage
+					? renderImage(tokens, idx, options, env, self)
+					: self.renderToken(tokens, idx, options)
+			}
 		}
 	},
 


### PR DESCRIPTION
Część obrazowa punktu 5. Znalezisko **P04 (P1)**.

## Co
Reguła `markdown-it` w `config.js` dopisuje `loading="lazy"` + `decoding="async"` do każdego obrazka w treści markdown (galerie historii, projektów, bazy wiedzy itd. — praktycznie zawsze poniżej pierwszego ekranu).

## Jak zweryfikować
1. `yarn build` — OK.
2. `dist/co-robimy/index.html`, `historia`, `projekty/*` — `<img … loading="lazy" decoding="async">`.

## Zakres / uwagi
- Karty na stronie głównej (`oj-card`) używają **CSS `background-image`**, nie `<img>` — nie da się ich natywnie zlazy-loadować bez przepisania na `<img>` (ryzyko wizualne, animacja hover), więc poza zakresem tej sesji.
- `width/height` plakatu na home → w #187. `srcset`/WebP dla plakatów i okładek → follow-up (wymaga generowania wariantów; miniatury `*-small.jpg` istnieją i można je podłączyć później).
- Konflikt z #189 mało prawdopodobny (inna sekcja `config.js`), w razie czego rozwiążę przy merge.