### PR TITLE
refactor(tokens): kolory mapy jako zmienne zamiast literałów

### DIFF
--- a/www/.vuepress/theme/components/oj-map.vue
+++ b/www/.vuepress/theme/components/oj-map.vue
@@ -265,6 +265,12 @@
 <style scoped lang='stylus'>
 @import '../styles/component'
 $oj-map-dark = $oj-green-free
+// Kolory mapy ogrodniczej — dekoracyjne, celowo jasniejsze niz zielen tekstu
+// ($oj-green-free jest teraz przyciemniona pod kontrast, A02). Tokeny zamiast
+// rozsypanych literalow (punkt 9 sesji 2 / U02 z AUDIT.md).
+$oj-map-green = #6ba568
+$oj-map-yellow = #f7e98b
+$oj-map-yellow-hover = #ffe954
 
 #oj-map
 	display block
@@ -326,19 +332,19 @@ $oj-map-dark = $oj-green-free
 	padding 0 1rem
 svg
 	.house
-		stroke #6ba568
+		stroke $oj-map-green
 		stroke-linejoin bevel
 		stroke-width 0.5px
 		&.open
 			cursor pointer
-			fill #f7e98b
+			fill $oj-map-yellow
 			&:hover
-				fill #ffe954
+				fill $oj-map-yellow-hover
 		&.closed
 			fill white
 
 	.house-number, text
-		fill #6ba568
+		fill $oj-map-green
 		font-family SC, Monaco, monospace
 		font-size 13px
 		font-weight 300


### PR DESCRIPTION
Realizuje punkt 9 Sesji 2 (design tokeny). Powiązane z **U02** z `AUDIT.md`.

## Co
W `oj-map.vue` rozsypane literały koloru zamienione na lokalne tokeny:
- `$oj-map-green = #6ba568` (obrys i numery domków),
- `$oj-map-yellow = #f7e98b` / `$oj-map-yellow-hover = #ffe954` (domki otwarte + hover).

Token dokumentuje **świadomą** różnicę: zieleń mapy ogrodniczej jest jaśniejsza niż zieleń tekstu — bo `$oj-green-free` została przyciemniona pod kontrast (A02, #187). Dzięki temu darkening tekstu nie „przypadkiem" zmieni koloru mapy.

## Jak zweryfikować
1. `yarn build` — OK.
2. Mapa renderuje się identycznie (wartości bez zmian, tylko nazwane).
3. W `oj-map.vue` brak literałów `#6ba568/#f7e98b/#ffe954` poza definicją tokenów.

## Zakres / co zostało
- Pełna centralizacja tokenów w `variables.styl` + usunięcie nieużywanych zmiennych (`$oj-ck`, `$oj-pink`, `$oj-dim`…) odłożone — kolidowałoby z #187 (który już zmienia `variables.styl`); do zrobienia po jego merge. Odnotowane w `DECYZJE.md`.