### PR TITLE
fix(cms): aktualizacja panelu — Decap CMS 3.15.1 + poprawka repo (R08)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ All templates are located in [www/.vuepress](www/.vuepress) folder.
 
 Vue components are written using `Pug` and `stylus`
 
-The markdown content can be edited using [Netlify CMS](https://www.netlifycms.org/)
+The markdown content can be edited using [Decap CMS](https://decapcms.org/) (panel: `/admin`).

--- a/www/.vuepress/public/admin/config.yml
+++ b/www/.vuepress/public/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  repo: Miastodwa/jazdow.pl
+  repo: Jazdow/jazdow.pl
   branch: master
   site_domain: cms.netlify.com
   accept_roles: #optional - accepts all users if left out

--- a/www/.vuepress/public/admin/index.html
+++ b/www/.vuepress/public/admin/index.html
@@ -9,8 +9,10 @@
 </head>
 
 <body>
-    <!-- Include the script that builds the page and powers Netlify CMS -->
-    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+    <!-- Decap CMS (utrzymywany nastepca zarchiwizowanego Netlify CMS) - wersja zapieta na sztywno + SRI -->
+    <script src="https://unpkg.com/decap-cms@3.15.1/dist/decap-cms.js"
+        integrity="sha384-in6eHztHveqQ7uMZ1fDaKlDmacQLFuLH2wWrFTiymyuS8zQ5bixwL8U3AeRi8h/L"
+        crossorigin="anonymous"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Panel `/admin` **zostaje** i zostaje zaktualizowany (zamiast usuwać — por. #197, które zostawiamy otwarte jako alternatywę).

## Co
- **`admin/index.html`**: `netlify-cms@^2.0.0` (zarchiwizowany, nieprzypięty) → **`decap-cms@3.15.1`** — utrzymywany następca Netlify CMS. Wersja **zapięta na sztywno** + **Subresource Integrity** (`sha384-…`, zweryfikowany lokalnie względem pliku z unpkg) + `crossorigin`. Konfiguracja Netlify CMS jest kompatybilna z Decap — `config.yml` bez zmian strukturalnych.
- **`admin/config.yml`**: `backend.repo` `Miastodwa/jazdow.pl` → **`Jazdow/jazdow.pl`** (znalezisko **R08** — wskazywał błędne repo).
- Backend bez zmian: `git-gateway` + Netlify Identity.

## Powiązania
- **Wymaga #190** (przywróconego) — CSP dla `/admin/*` pozwala na CDN/Identity/GitHub. Bez tego panel byłby blokowany.
- **Wyklucza się z #197** (usunięcie panelu) — to dwie ścieżki; ta jest aktywna. #197 zostaje otwarte jako opcja na przyszłość.

## ⚠️ Do przetestowania na deploy preview
Logowania i CMS nie da się w pełni sprawdzić lokalnie (wymaga Netlify Identity + git-gateway na wdrożeniu). **Przed mergem przetestować na deploy preview:** wejście na `/admin/`, logowanie przez Netlify Identity, załadowanie kolekcji i zapis (editorial workflow).

## Jak zweryfikować (lokalnie)
1. `yarn build` — OK.
2. `dist/admin/index.html` ładuje `decap-cms@3.15.1` z SRI; `dist/admin/config.yml` ma `repo: Jazdow/jazdow.pl`.