### PR TITLE
fix(cms): revert migracji do Decap — przywrócenie działającego panelu (hotfix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ All templates are located in [www/.vuepress](www/.vuepress) folder.
 
 Vue components are written using `Pug` and `stylus`
 
-The markdown content can be edited using [Decap CMS](https://decapcms.org/) (panel: `/admin`).
+The markdown content can be edited using [Netlify CMS](https://www.netlifycms.org/)

--- a/www/.vuepress/public/admin/config.yml
+++ b/www/.vuepress/public/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  repo: Jazdow/jazdow.pl
+  repo: Miastodwa/jazdow.pl
   branch: master
   site_domain: cms.netlify.com
   accept_roles: #optional - accepts all users if left out

--- a/www/.vuepress/public/admin/index.html
+++ b/www/.vuepress/public/admin/index.html
@@ -9,10 +9,8 @@
 </head>
 
 <body>
-    <!-- Decap CMS (utrzymywany nastepca zarchiwizowanego Netlify CMS) - wersja zapieta na sztywno + SRI -->
-    <script src="https://unpkg.com/decap-cms@3.15.1/dist/decap-cms.js"
-        integrity="sha384-in6eHztHveqQ7uMZ1fDaKlDmacQLFuLH2wWrFTiymyuS8zQ5bixwL8U3AeRi8h/L"
-        crossorigin="anonymous"></script>
+    <!-- Include the script that builds the page and powers Netlify CMS -->
+    <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
**Hotfix produkcyjny.** Po mergu #198 panel `/admin` przestał działać przy logowaniu.

## Diagnoza (z konsoli na produkcji)
Decap CMS 3.15.1 przy tym zestawie (git-gateway + Netlify Identity) wykonywał żądania **bezpośrednio do `api.github.com` bez tokena** (proxy git-gateway nie było używane): `x-ratelimit-limit: 60`, `remaining: 0` → limit **niezalogowanego** GitHuba wyczerpany → **403** „API rate limit exceeded". To regres samego silnika (Decap 3.x), **nie** CSP i **nie** zmiana `repo` (ID `162822754` = `Jazdow/jazdow.pl` niezależnie od nazwy; `Miastodwa` to stara nazwa przekierowująca tam samo).

## Co
`git revert` PR #198 — przywraca dokładnie stan sprzed aktualizacji:
- `admin/index.html` → `netlify-cms@^2.0.0` (działający silnik),
- `config.yml` → `repo: Miastodwa/jazdow.pl` (bez znaczenia funkcjonalnie — to samo repo),
- README → poprzednia treść.

Nagłówki bezpieczeństwa (#190) **zostają** — CSP na `/admin/*` jest luźny i niczego nie blokował (request doszedł do GitHuba). Panel działał wcześniej bez CSP, więc pod tym luźnym CSP też działa.

## Jak zweryfikować
1. `yarn build` — OK; `dist/admin/index.html` ładuje `netlify-cms@^2.0.0`.
2. Po deployu: `/admin/` → logowanie przez Netlify Identity + załadowanie kolekcji.

## Dalej (osobno, NIE na produkcji)
Migrację do Decap dopracować na **deploy preview**: prawdopodobnie git-gateway wymaga konkretnej wersji/konfiguracji Decap albo re-linkowania w Netlify. Nie wracać do Decap na `master` bez potwierdzenia na preview.