### PR TITLE
fix(mapa): każdy klikalny domek ma stronę (było 9 z 16, jest 15 z 15)

### DIFF
--- a/www/domki/10-2.md
+++ b/www/domki/10-2.md
@@ -1,0 +1,13 @@
+---
+permalink: domki/10-2
+title: Joanna Rajkowska
+layout: Houses
+address: Jazdów 10/2, Warszawa
+generic: true
+---
+
+Opis tego domku jest w przygotowaniu.
+
+Jeśli działasz w tym domku i chcesz uzupełnić opis — napisz na [wolny@jazdow.pl](mailto:wolny@jazdow.pl).
+
+[Wróć do mapy Osiedla Jazdów](/mapa/)

--- a/www/domki/10-5.md
+++ b/www/domki/10-5.md
@@ -1,0 +1,13 @@
+---
+permalink: domki/10-5
+title: Sołectwo
+layout: Houses
+address: Jazdów 10/5, Warszawa
+generic: true
+---
+
+Opis tego domku jest w przygotowaniu.
+
+Jeśli działasz w tym domku i chcesz uzupełnić opis — napisz na [wolny@jazdow.pl](mailto:wolny@jazdow.pl).
+
+[Wróć do mapy Osiedla Jazdów](/mapa/)

--- a/www/domki/3-18.md
+++ b/www/domki/3-18.md
@@ -1,0 +1,13 @@
+---
+permalink: domki/3-18
+title: Dom Kultury Śródmieście — Rotacyjny Dom Kultury na Jazdowie
+layout: Houses
+address: Jazdów 3/18, Warszawa
+generic: true
+---
+
+Opis tego domku jest w przygotowaniu.
+
+Jeśli działasz w tym domku i chcesz uzupełnić opis — napisz na [wolny@jazdow.pl](mailto:wolny@jazdow.pl).
+
+[Wróć do mapy Osiedla Jazdów](/mapa/)

--- a/www/domki/3-5.md
+++ b/www/domki/3-5.md
@@ -1,0 +1,13 @@
+---
+permalink: domki/3-5
+title: Chata Numinosum
+layout: Houses
+address: Jazdów 3/5, Warszawa
+generic: true
+---
+
+Opis tego domku jest w przygotowaniu.
+
+Jeśli działasz w tym domku i chcesz uzupełnić opis — napisz na [wolny@jazdow.pl](mailto:wolny@jazdow.pl).
+
+[Wróć do mapy Osiedla Jazdów](/mapa/)

--- a/www/domki/5a-4.md
+++ b/www/domki/5a-4.md
@@ -1,0 +1,13 @@
+---
+permalink: domki/5a-4
+title: Autonomiczna Przestrzeń Edukacyjna
+layout: Houses
+address: Jazdów 5a/4, Warszawa
+generic: true
+---
+
+Opis tego domku jest w przygotowaniu.
+
+Jeśli działasz w tym domku i chcesz uzupełnić opis — napisz na [wolny@jazdow.pl](mailto:wolny@jazdow.pl).
+
+[Wróć do mapy Osiedla Jazdów](/mapa/)

--- a/www/domki/8-1.md
+++ b/www/domki/8-1.md
@@ -1,0 +1,13 @@
+---
+permalink: domki/8-1
+title: Fundacja Odjazdów i Fundacja Potwory
+layout: Houses
+address: Jazdów 8/1, Warszawa
+generic: true
+---
+
+Opis tego domku jest w przygotowaniu.
+
+Jeśli działasz w tym domku i chcesz uzupełnić opis — napisz na [wolny@jazdow.pl](mailto:wolny@jazdow.pl).
+
+[Wróć do mapy Osiedla Jazdów](/mapa/)

--- a/www/mapa.md
+++ b/www/mapa.md
@@ -30,43 +30,43 @@ openHouses:
     coords: 992 616
     address: 3/5
     Name: Chata Numinosum
-    link: /3-5/
+    link: /domki/3-5/
   - name: Otwarta Pracownia Jazdów
     coords: 1039.5 645
     address: 3/6
     Name: Otwarta Pracownia Jazdów
-    link: /3-6/
+    link: /domki/3-6/
   - name: Pracownia Miejskiego Pszczelarstwa
     coords: 779.5 555
     address: 3/8
     Name: Miejskie Pszczoły
-    link: /3-8/
+    link: /domki/3-8/
   - name: Fundacja Pracownia Dóbr Wspólnych
     coords: 877 628
     address: 3/9
     Name: Solatorium
-    link: /3-9/
+    link: /domki/3-9/
   - name: PM na Trawie
     coords: 811 621.5
     address: 3/12
     Name: państwomiasto
-    link: /3-12/
+    link: /domki/3-12/
   - name: Dom Kultury Śródmieście - Rotacyjny Dom Kultury na Jazdowie
     coords: 854 720
     address: 3/18
     Name: Rotacyjny Dom Kultury
-    link: /3-18/
+    link: /domki/3-18/
   - name: Ambasada Muzyki Tradycyjnej
     coords: 763.5 667
     address: 3/20
     Name: Ambasada Muzyki Tradycyjnej
-    link: /3-20/
+    link: /domki/3-20/
   - name: Fundacja Bullerbyn na rzecz wspólnoty dzieci i dorosłych
     coords: 500.5 505.5
     address: 5a/1
-    link: /5a-1/
+    link: /domki/5a-1/
     Name: Fundacja Bullerbyn
-  - link: /5a-4/
+  - link: /domki/5a-4/
     address: 5a/4
     coords: 600 590.5
     Name: Autonomiczna Przestrzeń Edukacyjna
@@ -74,26 +74,21 @@ openHouses:
     coords: 506 423
     address: 7/14
     Name: Lado ABC
-    link: /7-14/
-  - name: Spółdzielnia Socjalna TERRA + Międzynarodowa Inicjatywa Humanitarna
-    coords: 433.5 470
-    address: 7/30
-    Name: Międzynarodowa Inicjatywa Humanitarna
-    link: /7-30/
-  - link: /8-1/
+    link: /domki/7-14/
+  - link: /domki/8-1/
     address: 8/1
     coords: 949 470
     Name: Fundacja Odjazdów i Fundacja Potwory
   - name: Osiem Przez Dwa
     coords: 1000 500
     address: 8/2
-    link: /8-2/
+    link: /domki/8-2/
     Name: Domek Przygody
-  - link: /10-2/
+  - link: /domki/10-2/
     address: 10/2
     coords: 759 395
     Name: Joanna Rajkowska
-  - link: /10-5/
+  - link: /domki/10-5/
     address: 10/5
     coords: 748 345
     Name: Sołectwo
@@ -101,7 +96,7 @@ openHouses:
     coords: 877 408
     address: 10/8
     Name: Towarzystwo Polska-Finlandia
-    link: /10-8/
+    link: /domki/10-8/
 closedHouses:
   - address: 3/4
     coords: 925 602


### PR DESCRIPTION
Pierwszy PR sesji 4.

## ⚠️ Najpierw korekta mojej diagnozy

**Znalezisko A1 z `ARCHITEKTURA.md` („wszystkie 16 linków do domków na mapie daje 404") było BŁĘDNE.** Zgłaszam to wprost, bo postawiłem je jako znalezisko numer jeden całej sesji 3.

Co ustaliłem, sprawdzając kod komponentu i zachowanie produkcji:
- `oj-map.vue` **w ogóle nie używa pola `link:`** z frontmattera (0 odwołań). Adres buduje z `house.address`:
  `$localePath + dir[$lang] + address.replace('/','-') + '/'` → `/domki/3-6/`.
- Zweryfikowane na żywo na produkcji: kliknięcie domku 3-6 na `/mapa/` przenosi do `/domki/3-6/`, status 200, właściwa treść.

Wyciągnąłem wniosek z samego frontmattera (`link: /3-6/`) i potwierdziłem, że `/3-6/` daje 404 — co jest prawdą, ale ten adres nigdy nie był używany. **Mapa działała poprawnie.**

## Prawdziwy błąd (to jest A5, nie A1)

Wszystkie 16 domków było klikalnych, ale **7 nie miało stron** i kończyło się na 404: `3-5`, `3-18`, `5a-4`, `7-30`, `8-1`, `10-2`, `10-5`. Zweryfikowane na produkcji (`/domki/3-5/` → 404, `/domki/3-6/` → 200).

**Efekt: 9 z 16 kliknięć w mapę działało.**

## Co zmienia ten PR

- **6 nowych stron-szablonów** — `3-5` (Chata Numinosum), `3-18` (Rotacyjny Dom Kultury), `5a-4` (Autonomiczna Przestrzeń Edukacyjna), `8-1` (Fundacja Odjazdów i Fundacja Potwory), `10-2` (Joanna Rajkowska), `10-5` (Sołectwo). Nazwy i adresy wzięte z danych mapy. Każda ma zaproszenie do uzupełnienia opisu i powrót do mapy.
- **Wpis 7/30 usunięty z `openHouses`** — zgodnie z Twoją decyzją. ⚠️ **Skutek wizualny: znacznik 7/30 znika z mapy.** Nie przeniosłem go do `closedHouses`, bo ta kategoria jest podpisana „Domek zamieszkały", a pod 7/30 działają organizacje (Spółdzielnia Socjalna TERRA + Międzynarodowa Inicjatywa Humanitarna) — byłaby to nieprawda na mapie. Jeśli wolisz zachować znacznik, powiedz — dorobię szablon jak dla pozostałych sześciu.
- **Pole `link:` zaktualizowane** na `/domki/<numer>/`. Jest martwe, ale było mylące — to właśnie ono wprowadziło w błąd audyt. Do rozważenia osobno: usunąć je całkiem z `mapa.md` i z konfiguracji CMS.

## Jak zweryfikować
1. `yarn build` — OK. Sitemapa 50 → 56 adresów.
2. Skrypt sprawdzający: **15 klikalnych domków, 15 ma stronę, 0 bez strony.**
3. Po wdrożeniu: klik w dowolny domek na `/mapa/` → strona 200 (wcześniej 7 z nich dawało 404).

## Co może się zepsuć
- Znacznik 7/30 znika z mapy (opisane wyżej).
- Sześć nowych stron ma treść zastępczą („Opis tego domku jest w przygotowaniu") — widoczną publicznie do czasu uzupełnienia. To świadomy kompromis: lepsze niż 404.
- Bez zmian URL-i istniejących stron.