### PR TITLE
fix(cms): wszystkie 49 plików widoczne w panelu (było 39)

### DIFF
--- a/www/.vuepress/public/admin/config.yml
+++ b/www/.vuepress/public/admin/config.yml
@@ -102,6 +102,29 @@ collections:
         widget: hidden
         default: true
 
+  # Projekty i baza wiedzy leza w podkatalogach, wiec kolekcja "PL Pages"
+  # (folder: www/) ich nie widzi. Bez tych dwoch kolekcji redaktor nie mial
+  # jak ich edytowac — patrz znalezisko A2 w ARCHITEKTURA.md.
+  - label: PL Projekty
+    name: projekty_pl
+    folder: www/projekty
+    create: true
+    fields:
+      - { label: Permalink, name: permalink, widget: string }
+      - { label: Title, name: title, widget: string }
+      - { label: TLDR, name: tldr, widget: text, required: false }
+      - { label: Body, name: body, widget: markdown }
+
+  - label: PL Baza wiedzy
+    name: baza_wiedzy_pl
+    folder: www/baza-wiedzy
+    create: true
+    fields:
+      - { label: Permalink, name: permalink, widget: string }
+      - { label: Title, name: title, widget: string }
+      - { label: TLDR, name: tldr, widget: text, required: false }
+      - { label: Body, name: body, widget: markdown }
+
   - label: PL Domki
     name: houses_pl
     folder: www/domki

--- a/www/dialog.md
+++ b/www/dialog.md
@@ -1,6 +1,7 @@
 ---
 permalink: dialog
 title: Listy otwarte
+generic: true
 ---
 
 ![flaga czerwona](/images/flag-red.png "flaga czerwona")

--- a/www/opp.md
+++ b/www/opp.md
@@ -2,6 +2,7 @@
 permalink: opp
 title: 🌱 Zasadź swoje 1.5% na Wolnym Jazdowie
 tldr: Partnerstwo Otwarty Jazdów Związek Stowarzyszeń - KRS 0000737179
+generic: true
 ---
 ![OPP baner górny](/images/opp-baner.png "OPP baner górny")
 

--- a/www/regulamin-darowizn.md
+++ b/www/regulamin-darowizn.md
@@ -1,6 +1,7 @@
 ---
 permalink: regulamin-darowizn
 title: Regulamin Darowizn
+generic: true
 ---
 
 ## § 1. Postanowienia ogólne

--- a/www/statut.md
+++ b/www/statut.md
@@ -1,6 +1,7 @@
 ---
 permalink: statut
 title: Statut
+generic: true
 ---
 **[Statut Związku Stowarzyszeń Partnerstwo Otwarty Jazdów](/dokumenty/ZS-POJ_statut.pdf)**
 

--- a/www/wspolpraca.md
+++ b/www/wspolpraca.md
@@ -1,6 +1,7 @@
 ---
 permalink: wspolpraca
 title: Współpraca
+generic: true
 ---
 
 Wolny Jazdów to miejsce międzysektorowych współprac – otwarte na wspólne tworzenie wydarzeń kulturalnych, projektów społecznych, działań artystycznych, edukacyjnych i sąsiedzkich. Od lat tworzymy przestrzeń, w której spotykają się organizacje społeczne, osoby artystyczne, aktywistyczne, mieszkanki i mieszkańcy, instytucje publiczne, inicjatywy oddolne oraz partnerzy biznesowi.


### PR DESCRIPTION
Drugi PR sesji 4. Znalezisko **A2** z `ARCHITEKTURA.md` — to znalezisko **potwierdziło się w całości** (w odróżnieniu od wycofanego A1).

## Problem
Redaktor **nie mógł edytować 10 z 49 plików** przez panel `/admin`. Wśród nich `dialog.md` — czyli treść z **pierwszej pozycji menu** — oraz `wspolpraca.md`.

Dwie niezależne przyczyny:
1. Kolekcja „PL Pages" ma `filter: {field: generic, value: true}`, więc każdy plik bez tej flagi znikał z panelu.
2. Katalogi `www/projekty` i `www/baza-wiedzy` nie były objęte **żadną** kolekcją.

## Co zmienia
- **`generic: true`** dopisane do: `dialog.md`, `wspolpraca.md`, `statut.md`, `regulamin-darowizn.md`, `opp.md`.
- **Dwie nowe kolekcje** w `admin/config.yml`: „PL Projekty" (`www/projekty`) i „PL Baza wiedzy" (`www/baza-wiedzy`) — obejmują `wspolzarzadzanie`, `archiwum`, `archiwum-dolacz`, `festiwal` i materiał z bazy wiedzy.

## Jak zweryfikować
1. `yarn build` — OK.
2. Skrypt sprawdzający pokrycie kolekcjami: **49/49 plików widocznych** (było 39/49).
3. `generic` to pole techniczne (`widget: hidden`) — **0 wystąpień w wyrenderowanym HTML**, treść i wygląd stron bez zmian.
4. Po wdrożeniu: w `/admin` powinny pojawić się kolekcje „PL Projekty" i „PL Baza wiedzy", a `dialog` i `wspolpraca` — w „PL Pages".

## Co może się zepsuć
- Zmiana dotyka `admin/config.yml`. **Warto kliknąć po panelu na deploy preview** przed mergem — po doświadczeniu z #198/#199 nie zakładam, że konfiguracja CMS działa, dopóki jej nie zobaczę.
- Nowe kolekcje mają `create: true`, więc redaktor może dodać nowy projekt. Jeśli wolisz, żeby tylko edytował istniejące — zmienię na `false`.
- Uwaga architektoniczna: `filter: generic` zostaje jako pułapka (każda nowa strona bez flagi znowu zniknie). Docelowo usuwa go restrukturyzacja katalogów, którą zaakceptowałeś — ta poprawka jest doraźna i wtedy przestanie być potrzebna.