### PR TITLE
docs(license): licencja repozytorium — MIT dla kodu, CC BY-NC-SA 4.0 dla treści

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,102 @@
+# Licencja
+
+Repozytorium `jazdow.pl` zawiera dwa rodzaje materiałów, objęte różnymi licencjami:
+**kod źródłowy** oraz **treści redakcyjne**. Część materiałów jest z licencji wyłączona —
+patrz sekcja [Wyłączenia](#wyłączenia).
+
+Właściciel praw: **Partnerstwo Otwarty Jazdów Związek Stowarzyszeń**, KRS 0000737179
+(dalej: „Partnerstwo").
+
+---
+
+## 1. Kod źródłowy — licencja MIT
+
+Dotyczy: motywu VuePress (`www/.vuepress/theme/`), konfiguracji (`www/.vuepress/config.js`,
+`themeConfig.json`), skryptów (`scripts/`), plików budowania (`package.json`, `netlify.toml`)
+oraz pozostałego kodu w tym repozytorium.
+
+```
+MIT License
+
+Copyright (c) 2017-2026 Partnerstwo Otwarty Jazdów Związek Stowarzyszeń
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## 2. Treści — licencja CC BY-SA 4.0
+
+Dotyczy: tekstów w plikach Markdown (`www/**/*.md`) oraz własnych grafik informacyjnych
+Partnerstwa, o ile przy konkretnym materiale nie zaznaczono inaczej.
+
+Materiały te są dostępne na licencji
+[Creative Commons Uznanie autorstwa – Na tych samych warunkach 4.0 Międzynarodowe (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/deed.pl).
+
+Oznacza to, że możesz je kopiować, rozpowszechniać, przerabiać i wykorzystywać komercyjnie,
+pod warunkiem że:
+
+- **podasz autorstwo** — wskażesz Partnerstwo Otwarty Jazdów jako źródło i podlinkujesz
+  https://jazdow.pl oraz licencję,
+- **zachowasz warunki** — utwory zależne udostępnisz na tej samej licencji (CC BY-SA 4.0).
+
+Sugerowana formuła oznaczenia:
+
+> Źródło: [Partnerstwo Otwarty Jazdów](https://jazdow.pl), licencja
+> [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.pl)
+
+## Wyłączenia
+
+Poniższe materiały **nie są** objęte licencjami z punktów 1 i 2. Ich wykorzystanie wymaga
+odrębnej zgody właściwego uprawnionego:
+
+- **Znaki i identyfikacja wizualna Partnerstwa** — logo (`oj-logo.svg`), ikony aplikacji,
+  favicon, nazwy „Otwarty Jazdów", „Wolny Jazdów" i „Partnerstwo Otwarty Jazdów".
+  Można ich używać wyłącznie do odesłania do Partnerstwa, bez sugerowania jego poparcia
+  lub powiązania.
+- **Fotografie i materiały wideo** (m.in. `www/.vuepress/public/images/`,
+  `www/.vuepress/public/dyplomacja/`) — prawa autorskie pozostają przy autorach zdjęć,
+  a utrwalone osoby zachowują prawo do wizerunku. Wszelkie prawa zastrzeżone, chyba że
+  przy konkretnym pliku wskazano inaczej.
+- **Plakaty i materiały graficzne wydarzeń** (`www/.vuepress/public/plakaty/`) — prawa
+  autorskie pozostają przy ich autorach i organizatorach wydarzeń.
+- **Kroje pism** w `www/.vuepress/public/fonts/` — objęte licencjami podmiotów trzecich.
+  Obecność plików w repozytorium nie oznacza udzielenia jakichkolwiek praw do nich.
+- **Dokumenty PDF** w `www/.vuepress/public/dokumenty/` i
+  `www/.vuepress/public/sprawozdania/` — statut, sprawozdania i inne dokumenty
+  organizacyjne publikowane w celach informacyjnych i sprawozdawczych.
+- **Zależności zewnętrzne** (`node_modules/`) — objęte własnymi licencjami swoich autorów.
+
+## Kontakt
+
+Pytania o wykorzystanie materiałów: [wolny@jazdow.pl](mailto:wolny@jazdow.pl)
+
+---
+
+## Summary in English
+
+This repository is dual-licensed. **Source code** (VuePress theme, configuration, build
+scripts) is available under the **MIT License**. **Editorial content** (Markdown texts and
+the organisation's own informational graphics) is available under
+**[CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)**, with attribution to
+Partnerstwo Otwarty Jazdów and a link to https://jazdow.pl.
+
+The following are **excluded** from both licences and require separate permission: the
+organisation's logo and visual identity, photographs and video (rights held by their
+authors; depicted persons retain image rights), the bundled font files (third-party
+licences), the organisational PDF documents, and third-party dependencies in
+`node_modules/`.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -39,25 +39,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-## 2. Treści — licencja CC BY-SA 4.0
+## 2. Treści — licencja CC BY-NC-SA 4.0
 
 Dotyczy: tekstów w plikach Markdown (`www/**/*.md`) oraz własnych grafik informacyjnych
 Partnerstwa, o ile przy konkretnym materiale nie zaznaczono inaczej.
 
 Materiały te są dostępne na licencji
-[Creative Commons Uznanie autorstwa – Na tych samych warunkach 4.0 Międzynarodowe (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/deed.pl).
+[Creative Commons Uznanie autorstwa – Użycie niekomercyjne – Na tych samych warunkach 4.0 Międzynarodowe (CC BY-NC-SA 4.0)](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.pl).
 
-Oznacza to, że możesz je kopiować, rozpowszechniać, przerabiać i wykorzystywać komercyjnie,
-pod warunkiem że:
+Oznacza to, że możesz je kopiować, rozpowszechniać i przerabiać, pod warunkiem że:
 
 - **podasz autorstwo** — wskażesz Partnerstwo Otwarty Jazdów jako źródło i podlinkujesz
   https://jazdow.pl oraz licencję,
-- **zachowasz warunki** — utwory zależne udostępnisz na tej samej licencji (CC BY-SA 4.0).
+- **nie użyjesz ich komercyjnie** — wykorzystanie nastawione głównie na uzyskanie
+  korzyści majątkowej lub wynagrodzenia wymaga odrębnej zgody Partnerstwa,
+- **zachowasz warunki** — utwory zależne udostępnisz na tej samej licencji
+  (CC BY-NC-SA 4.0).
 
 Sugerowana formuła oznaczenia:
 
 > Źródło: [Partnerstwo Otwarty Jazdów](https://jazdow.pl), licencja
-> [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.pl)
+> [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed.pl)
+
+Chcesz wykorzystać treści komercyjnie? Napisz na [wolny@jazdow.pl](mailto:wolny@jazdow.pl) —
+zgody udzielamy indywidualnie.
 
 ## Wyłączenia
 
@@ -92,8 +97,9 @@ Pytania o wykorzystanie materiałów: [wolny@jazdow.pl](mailto:wolny@jazdow.pl)
 This repository is dual-licensed. **Source code** (VuePress theme, configuration, build
 scripts) is available under the **MIT License**. **Editorial content** (Markdown texts and
 the organisation's own informational graphics) is available under
-**[CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/)**, with attribution to
-Partnerstwo Otwarty Jazdów and a link to https://jazdow.pl.
+**[CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/)** — attribution to
+Partnerstwo Otwarty Jazdów with a link to https://jazdow.pl, non-commercial use only, and
+derivative works under the same licence. For commercial use, contact wolny@jazdow.pl.
 
 The following are **excluded** from both licences and require separate permission: the
 organisation's logo and visual identity, photographs and video (rights held by their

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ This repository is dual-licensed — see [LICENSE.md](LICENSE.md) for the full t
 
 - **Source code** (theme, configuration, build scripts) — [MIT](LICENSE.md#1-kod-źródłowy--licencja-mit).
 - **Editorial content** (Markdown texts and the organisation's own informational graphics) —
-  [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/), with attribution to
-  Partnerstwo Otwarty Jazdów and a link to https://jazdow.pl.
+  [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/): attribution to
+  Partnerstwo Otwarty Jazdów with a link to https://jazdow.pl, non-commercial use only,
+  derivative works under the same licence. For commercial use, contact wolny@jazdow.pl.
 
 **Excluded from both licences** (separate permission required): the logo and visual identity,
 photographs and video in `www/.vuepress/public/images/` and `dyplomacja/`, event posters in

--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ All templates are located in [www/.vuepress](www/.vuepress) folder.
 Vue components are written using `Pug` and `stylus`
 
 The markdown content can be edited using [Netlify CMS](https://www.netlifycms.org/)
+
+## License
+
+This repository is dual-licensed — see [LICENSE.md](LICENSE.md) for the full terms.
+
+- **Source code** (theme, configuration, build scripts) — [MIT](LICENSE.md#1-kod-źródłowy--licencja-mit).
+- **Editorial content** (Markdown texts and the organisation's own informational graphics) —
+  [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/), with attribution to
+  Partnerstwo Otwarty Jazdów and a link to https://jazdow.pl.
+
+**Excluded from both licences** (separate permission required): the logo and visual identity,
+photographs and video in `www/.vuepress/public/images/` and `dyplomacja/`, event posters in
+`plakaty/`, the bundled fonts in `fonts/`, the organisational PDFs in `dokumenty/` and
+`sprawozdania/`, and third-party dependencies.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jazdow.pl",
   "private": true,
-  "license": "UNLICENSED",
+  "license": "MIT",
   "scripts": {
     "dev": "cross-env NODE_OPTIONS=--openssl-legacy-provider vuepress dev www",
     "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider vuepress build www && node scripts/postbuild.js"

--- a/www/.vuepress/theme/components/oj-footer.vue
+++ b/www/.vuepress/theme/components/oj-footer.vue
@@ -13,6 +13,8 @@ footer#oj-footer
 			a.social-icon(v-for="item in $site.themeConfig.social", :key="item.type", :href="item.href", :aria-label="socialLabel(item.type)", target="_blank", rel="noopener", v-html="socialIcon(item.type)")
 		.links
 			router-link(v-for="link in $site.themeConfig.links[lang]" :key="link.to" :to="link.to") {{link.title}}
+		.license
+			a(:href="license.href", target="_blank", rel="noopener") {{license.title}}
 </template>
 
 <script>
@@ -39,12 +41,28 @@ const socialIcons = {
 	x: svg('M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z')
 }
 
+// Informacja o licencji repozytorium (LICENSE.md): kod MIT, tresci CC BY-NC-SA 4.0.
+// Trzymane w komponencie, jak socialLabels - to stala informacja, nie dane redakcyjne.
+const licenseNotice = {
+	pl: {
+		title: 'Licencja: kod MIT, treści CC BY-NC-SA 4.0',
+		href: 'https://github.com/Jazdow/jazdow.pl/blob/master/LICENSE.md'
+	},
+	en: {
+		title: 'Licence: MIT code, CC BY-NC-SA 4.0 content',
+		href: 'https://github.com/Jazdow/jazdow.pl/blob/master/LICENSE.md'
+	}
+}
+
 export default {
 	name: 'oj-footer',
 
 	computed: {
 		lang(){
 			return this.$lang.substring(0, 2)
+		},
+		license(){
+			return licenseNotice[this.lang] || licenseNotice.pl
 		}
 	},
 	methods: {
@@ -146,4 +164,10 @@ export default {
 		margin-top 2.5rem
 		a
 			font-size 1.2rem
+
+	// LICENSE
+	.license
+		margin-top 1rem
+		a
+			font-size 1rem
 </style>


### PR DESCRIPTION
## Po co

Repozytorium nie miało licencji, a `package.json` deklarował `"UNLICENSED"` — czyli formalnie nikt nie mógł legalnie użyć ani kodu, ani treści. Jednocześnie repo łączy trzy różne rodzaje materiałów, więc jedna licencja tu nie wystarcza:

- **kod** — motyw VuePress, komponenty, skrypty budowania,
- **treści redakcyjne** — ~30 plików Markdown (baza wiedzy, deklaracja, regulaminy),
- **materiały osób trzecich** — ~283 zdjęcia, plakaty, komercyjne kroje pism.

## Co zmienia

| Zakres | Licencja |
|---|---|
| Kod źródłowy (motyw, konfiguracja, `scripts/`) | MIT |
| Teksty `www/**/*.md` + własne grafiki informacyjne | CC BY-NC-SA 4.0 |
| Logo, zdjęcia, plakaty, fonty, dokumenty PDF | wyłączone — wymagają odrębnej zgody |

- `LICENSE.md` — pełne warunki wraz z wyłączeniami i podsumowaniem po angielsku
- `package.json` — `"UNLICENSED"` → `"MIT"`, żeby metadane nie przeczyły LICENSE.md
- `README.md` — sekcja „License" z odesłaniem do pełnego tekstu
- `oj-footer.vue` — link „Licencja: kod MIT, treści CC BY-NC-SA 4.0" w stopce strony, kierujący do `LICENSE.md`

Dane wzięte z repo: właściciel **Partnerstwo Otwarty Jazdów Związek Stowarzyszeń**, KRS 0000737179 (z `www/opp.md`), kontakt `wolny@jazdow.pl` (z `themeConfig.json`), lata 2017–2026 z historii commitów.

## Dlaczego takie licencje

**MIT dla kodu** — celem jest, żeby inna inicjatywa sąsiedzka mogła wziąć ten motyw i postawić sobie stronę. GPL/AGPL stawiałaby niepotrzebną barierę.

**CC BY-NC-SA 4.0 dla treści** — decyzja Partnerstwa: treści można swobodnie kopiować i przerabiać w celach niekomercyjnych, z podaniem źródła i na tej samej licencji, natomiast wykorzystanie komercyjne wymaga indywidualnej zgody (`wolny@jazdow.pl`). Warto mieć świadomość konsekwencji klauzuli NC: treści na tej licencji nie mogą trafić do Wikipedii, a redakcje prasowe i wydawnictwa muszą każdorazowo pytać o zgodę.

**Wyłączenia** są konieczne — bez nich licencja obiecywałaby prawa, których Partnerstwo nie ma: przy zdjęciach w grę wchodzą prawa autorskie fotografów i wizerunek utrwalonych osób, a fonty w `public/fonts/` (Lemur, HK Grotesk i inne) mają licencje podmiotów trzecich.

## Stopka

Link jest osobną linią pod istniejącymi linkami stopki, teksty PL/EN trzymane w komponencie obok `socialLabels`. Zewnętrzny URL przez `<a target="_blank" rel="noopener">`, nie `router-link` — ten drugi doklejałby base URL.

Sprawdzone na serwerze deweloperskim: `/` renderuje wariant polski, `/en/` angielski, link trafia do `LICENSE.md`, rozmiar tekstu (1rem) zgodny z resztą treści stopki, pozycja pod blokiem linków.

## Do sprawdzenia przed mergem

Jeśli część treści powstała z dotacji publicznej (m.st. Warszawa, NIW, FIO), umowa dotacyjna mogła już narzucić konkretną licencję — zwykle CC BY 3.0 PL lub CC BY-SA, czyli bez klauzuli NC. Wtedy dla tych materiałów trzeba dostosować się do umowy.

Link w stopce wskazuje na `LICENSE.md` w gałęzi `master` — zadziała po mergu tego PR-a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)